### PR TITLE
Another monkey patch to cleanup unused memory

### DIFF
--- a/src/main/scala/net/lag/kestrel/admin/SwiftypeStatsListener.scala
+++ b/src/main/scala/net/lag/kestrel/admin/SwiftypeStatsListener.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2011 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.lag.kestrel
+package admin
+
+import scala.collection.{JavaConversions, Map, mutable, immutable}
+import com.twitter.ostrich.stats._
+
+// This is a hacky monkey-patch that stops memory from leaking.
+class SwiftypeStatsListener(collection: StatsCollection) extends StatsListener(collection) {
+
+  // These shadow StatsListener immutable fields and so should always point to the same object
+  val lastCounterMap = getSuperClassPrivateField("lastCounterMap").asInstanceOf[mutable.HashMap[String, Long]]
+  val lastMetricMap = getSuperClassPrivateField("lastMetricMap").asInstanceOf[mutable.HashMap[String, Histogram]]
+
+  override def getCounters(): Map[String, Long] = synchronized {
+    val counters = super.getCounters()
+    lastCounterMap.retain { case (k, v) => counters.contains(k) }
+    counters
+  }
+
+  override def getMetrics(): Map[String, Histogram] = synchronized {
+    val metrics = super.getMetrics()
+    lastMetricMap.retain { case (k, v) => metrics.contains(k) }
+    metrics
+  }
+
+  private def getSuperClassPrivateField(fieldName: String): Object = {
+    val field = getClass().getSuperclass().getDeclaredField("com$twitter$ostrich$stats$StatsListener$$" + fieldName)
+    field.setAccessible(true)
+    field.get(this)
+  }
+}

--- a/src/main/scala/net/lag/kestrel/admin/SwiftypeTimeSeriesCollector.scala
+++ b/src/main/scala/net/lag/kestrel/admin/SwiftypeTimeSeriesCollector.scala
@@ -59,7 +59,7 @@ class SwiftypeTimeSeriesCollector(collection: StatsCollection) extends Service {
   var lastCollection: Time = Time.epoch
 
   val collector = new PeriodicBackgroundProcess("TimeSeriesCollector", 1.minute) {
-    val listener = new StatsListener(collection)
+    val listener = new SwiftypeStatsListener(collection)
 
     def periodic() {
       val stats = listener.get()

--- a/src/test/scala/net/lag/kestrel/admin/SwiftypeTimeSeriesCollectorSpec.scala
+++ b/src/test/scala/net/lag/kestrel/admin/SwiftypeTimeSeriesCollectorSpec.scala
@@ -158,6 +158,8 @@ class SwiftypeTimeSeriesCollectorSpec extends SpecificationWithJUnit {
         data("counter:whales.tps")(58) mustEqual List(1.minute.ago.inSeconds, 0)
         data("counter:whales.tps")(59) mustEqual List(Time.now.inSeconds, 10)
 
+        collector.collector.listener.lastCounterMap.keys must contain("whales.tps")
+
         time.advance(1.minute)
         Stats.removeCounter("whales.tps")
 
@@ -171,6 +173,8 @@ class SwiftypeTimeSeriesCollectorSpec extends SpecificationWithJUnit {
             e.getMessage mustEqual "key not found: counter:whales.tps"
           }
         }
+
+        collector.collector.listener.lastCounterMap.keys must not contain("whales.tps")
       }
     }
   }


### PR DESCRIPTION
These lastMetric and lastCounter maps were being
added to and never removed from. This cleans them
up every time they’re accessed.