### PR TITLE
Better queue expiration

### DIFF
--- a/src/main/scala/net/lag/kestrel/PersistentQueue.scala
+++ b/src/main/scala/net/lag/kestrel/PersistentQueue.scala
@@ -190,7 +190,7 @@ class PersistentQueue(val name: String, persistencePath: String, @volatile var c
    * and the last queue modification occuring longer than maxQueueAge ago.
    */
    def isReadyForExpiration: Boolean = synchronized {
-    config.maxQueueAge.isDefined && queue.isEmpty && (Time.now > _lastModificationTime + config.maxQueueAge.get)
+    config.maxQueueAge.isDefined && queue.isEmpty && openTransactions.isEmpty && (Time.now > _lastModificationTime + config.maxQueueAge.get)
   }
 
   private def disallowRewritesForDelay() {

--- a/src/main/scala/net/lag/kestrel/PersistentQueue.scala
+++ b/src/main/scala/net/lag/kestrel/PersistentQueue.scala
@@ -47,7 +47,7 @@ class PersistentQueue(val name: String, persistencePath: String, @volatile var c
   private var _currentAge: Time = Time.epoch
 
   // time the queue was created
-  private var _createTime = Time.now
+  private val _createTime = Time.now
 
   // time the most recent modification occurred
   private var _lastModificationTime = Time.now
@@ -102,14 +102,14 @@ class PersistentQueue(val name: String, persistencePath: String, @volatile var c
   // # of items in the queue (including those not in memory)
   private var queueLength: Long = 0
 
-  private var queue = new mutable.Queue[QItem]
+  private val queue = new mutable.Queue[QItem]
 
   private var _memoryBytes: Long = 0
 
   private var closed = false
   private var paused = false
 
-  private var journal =
+  private val journal =
     new Journal(new File(persistencePath).getCanonicalFile, name, journalSyncScheduler, config.syncJournal)
 
   private val waiters = new DeadlineWaitQueue(timer)

--- a/src/test/scala/net/lag/kestrel/PersistentQueueSpec.scala
+++ b/src/test/scala/net/lag/kestrel/PersistentQueueSpec.scala
@@ -1177,7 +1177,7 @@ class PersistentQueueSpec extends SpecificationWithJUnit
 
           q.confirmRemove(item.get.xid)
 
-          // confirmRemove() resets the last modification timestamp
+          // confirmRemove() resets the last access timestamp
           time.advance(91.seconds)
 
           q.isReadyForExpiration mustEqual true

--- a/src/test/scala/net/lag/kestrel/PersistentQueueSpec.scala
+++ b/src/test/scala/net/lag/kestrel/PersistentQueueSpec.scala
@@ -1150,6 +1150,40 @@ class PersistentQueueSpec extends SpecificationWithJUnit
         }
       }
     }
+
+    "active queue does not expire if there are open transactions" in {
+      withTempFolder {
+        Time.withCurrentTimeFrozen { time =>
+          val config = new QueueBuilder {
+            keepJournal = false
+            maxQueueAge = 90.seconds
+          }.apply()
+          val q = new PersistentQueue("wu_tang", folderName, config, timer, scheduler)
+          q.setup()
+
+          q.isReadyForExpiration mustEqual false
+
+          q.add("method man".getBytes, None) mustEqual true
+          val item = q.remove(true)
+
+          q.length mustEqual 0
+          q.openTransactionCount mustEqual 1
+
+          q.isReadyForExpiration mustEqual false
+
+          time.advance(91.seconds)
+
+          q.isReadyForExpiration mustEqual false
+
+          q.confirmRemove(item.get.xid)
+
+          // confirmRemove() resets the last modification timestamp
+          time.advance(91.seconds)
+
+          q.isReadyForExpiration mustEqual true
+        }
+      }
+    }
   }
 
   "PersistentQueue with item expiry" should {


### PR DESCRIPTION
There are two fixes here:

1. Only expire queues if it's been max age since a modifying operation has occurred (remove, add, confirm, or abort) instead of if it's been max age since creation. This will hopefully reduce queue churn for us significantly. Our queues often empty because our workers keep up with them and Kestrel blocking to read from disk every expiration interval to re-read all the queues is bad. It also causes us to drop queue items because if we're still writing while the queue is being expired those items get lost.

2. Prevent expiring the queue when there are still open transactions. Until they've been confirmed open transactions are just as important as any other queue item!